### PR TITLE
Make shouldShowDay function faster

### DIFF
--- a/components/marathon/schedule/List.vue
+++ b/components/marathon/schedule/List.vue
@@ -187,11 +187,15 @@ export default Vue.extend({
       if (index === 0) {
         return true;
       }
+
       // Otherwise, only show when the day transitioned
       const currentRun = new Date(this.runs![index].date);
       // We have an implicit index test for the index=0 case, so this is always safe
       const previousRun = new Date(this.runs![index - 1].date);
-      return this.$i18n.d(currentRun, 'longDate') !== this.$i18n.d(previousRun, 'longDate');
+
+      return currentRun.getDate() !== previousRun.getDate() ||
+        currentRun.getMonth() !== previousRun.getMonth() ||
+        currentRun.getFullYear() !== previousRun.getFullYear();
     },
     ...mapActions({
       getSchedule: 'api/schedule/get',


### PR DESCRIPTION
Making the shouldShowDay function faster by not translating.

## Testing
The function speed was tested during mount by calling the `shouldShowDay` function a million times while only making changes to the `shouldShowDay` function to see what would be the fastest.

**Benchmark code**
```js
console.time('bench');
for (let i = 0; i < 1000000; i++) {
  const out = this.shouldShowDay(1);
}
console.timeEnd('bench');
```

**Results**

| Old times (ms)    | New times (ms)    |
| ----------------- | ----------------- |
| 4923.033935546875 | 1069.244140625    |
| 4887.639892578125 | 1139.80419921875  |
| 5042.223876953125 | 1125.24609375     |
| 4901.51513671875  | 1120.745849609375 |
| 4878.923828125    | 1103.1220703125   |

*Note that times are for 1 million iterations*

## Conclusion

This change results in a function that is close to 5x faster 😮
