### PR TITLE
fix lopsided borders on user link images

### DIFF
--- a/src/app/elements/user-link/user-link.component.scss
+++ b/src/app/elements/user-link/user-link.component.scss
@@ -5,6 +5,6 @@
 img {
   border-radius: 50%;
   height: 1.5em;
-  padding-right: 5px;
+  margin-right: 5px;
   transform: translate(0%, 25%);
 }


### PR DESCRIPTION
Profile images displayed in the submitted runs view have a lopsided border:
![image](https://github.com/esamarathon/oengus-webapp/assets/15526977/80de6cc6-f37d-42a7-809b-fb6dd087ae43)


this is because these images use padding to indent text to the right of them, incorrectly:
![image](https://github.com/esamarathon/oengus-webapp/assets/15526977/6477db09-fd28-4cc6-8125-66457c3b0b51)

this padding pushes the center of the border computed by at least Firefox 115.5.0esr (64-bit) to the right, which makes the circle lopsided.

This PR changes the padding to a margin, which fixes the issue and is more semantically correct:
![image](https://github.com/esamarathon/oengus-webapp/assets/15526977/70f5e9c3-2113-43bb-a050-52ff60591190)
